### PR TITLE
Change return type of function translatecolor

### DIFF
--- a/src/Vazzi/ColorParticle/ColorParticle.php
+++ b/src/Vazzi/ColorParticle/ColorParticle.php
@@ -46,7 +46,7 @@ class ColorParticle extends PluginBase
         $adminPerm->addChild('colorparticle.permission.rainbow', true);
 	}
 
-	public function translateColor($color, Player $player): DustParticle
+	public function translateColor($color, Player $player): DustParticle|String|null
     {
         return match ($color) {
             "Red" => new DustParticle(new Color(255, 0, 0)),


### PR DESCRIPTION
Return Typ DustParticle would not work with Rainbow Particle, because it returns String. If this would be changed I can also merge it with the main repository. Otherwise you get an error when you select Rainbow.